### PR TITLE
Buyer App infinite scroller

### DIFF
--- a/buyer-api/src/facades/getOrdersFacade.js
+++ b/buyer-api/src/facades/getOrdersFacade.js
@@ -137,7 +137,7 @@ const getOrdersForBuyer = async (
   limit = undefined,
 ) => {
   const orderAddresses = await dataExchange.getOrdersForBuyer(buyerAddress);
-  const upperBound = limit && offset > 0 ? offset + limit : orderAddresses.length;
+  const upperBound = limit && offset >= 0 ? offset + limit : orderAddresses.length;
   const ordersPage = orderAddresses.slice(offset, upperBound);
 
   const dataOrders = ordersPage.map(orderAddress =>

--- a/buyer-api/src/facades/getOrdersFacade.js
+++ b/buyer-api/src/facades/getOrdersFacade.js
@@ -146,4 +146,24 @@ const getOrdersForBuyer = async (
   return Promise.all(dataOrders);
 };
 
-export { getDataOrder, getOrdersForBuyer, fetchAndCacheDataOrder };
+/**
+ * @async
+ * @function getOrdersAmountForBuyer
+ * @param {Object} buyerAddress the buyer's Ethereum address.
+ * @param {Object} ordersCache Redis storage used for orders caching
+ * @throws When can not connect to blockchain or cache is not set up correctly.
+ * @returns {Promise} Promise which resolves to the list of orders.
+ */
+const getOrdersAmountForBuyer = async (
+  buyerAddress,
+  ordersCache,
+) => {
+  const orderAddresses = await dataExchange.getOrdersForBuyer(buyerAddress);
+
+  const dataOrders = orderAddresses.map(orderAddress =>
+    getDataOrder(orderAddress, ordersCache));
+
+  return Promise.all(dataOrders);
+};
+
+export { getDataOrder, getOrdersForBuyer, fetchAndCacheDataOrder, getOrdersAmountForBuyer };

--- a/buyer-api/src/facades/index.js
+++ b/buyer-api/src/facades/index.js
@@ -12,7 +12,7 @@ import {
 } from './createDataOrderFacade';
 import addNotariesToOrderFacade from './addNotariesToOrderFacade';
 import closeDataOrderFacade from './closeDataOrderFacade';
-import { getOrdersForBuyer, fetchAndCacheDataOrder } from './getOrdersFacade';
+import { getOrdersForBuyer, fetchAndCacheDataOrder, getOrdersAmountForBuyer } from './getOrdersFacade';
 
 export { getNotaryInfo, getNotariesInfo, fetchAndCacheNotary } from './notariesFacade';
 
@@ -29,4 +29,5 @@ export {
   onAddDataResponseSent,
   onCloseDataResponseSent,
   fetchAndCacheDataOrder,
+  getOrdersAmountForBuyer,
 };

--- a/buyer-api/src/routes/dataOrders/createDataOrder.js
+++ b/buyer-api/src/routes/dataOrders/createDataOrder.js
@@ -64,16 +64,12 @@ router.get(
 
     const { stores: { ordersCache } } = req.app.locals;
 
-    const ordersResult = getOrdersAmountForBuyer(address, ordersCache);
+    const orders = await getOrdersAmountForBuyer(address, ordersCache);
 
-    const [orders] = await Promise.all([
-      ordersResult,
-    ]);
+    const totalClosedOrders = orders.filter(order => order.isClosed).length;
+    const totalOpenOrders = orders.filter(order => !order.isClosed).length;
 
-    const closedOrdersLength = orders.filter(order => order.isClosed).length;
-    const openOrdersLength = orders.filter(order => !order.isClosed).length;
-
-    res.json({ closedOrdersLength, openOrdersLength });
+    res.json({ totalClosedOrders, totalOpenOrders });
   }),
 );
 

--- a/buyer-app/buyer-app/src/components/buyer/Buyer.js
+++ b/buyer-app/buyer-app/src/components/buyer/Buyer.js
@@ -76,7 +76,7 @@ class Buyer extends React.Component {
 
   handleScroll = (e) =>{
     // const bottom = e.target.scrollingElement.scrollHeight - e.target.scrollingElement.scrollTop === e.target.scrollingElement.clientHeight;
-    const bottom = window.innerHeight + document.documentElement.scrollTop < document.documentElement.offsetHeight;
+    const bottom = window.innerHeight + document.documentElement.scrollTop >= document.documentElement.offsetHeight;
     const {
       activeDataOrders,
       dataOrdersAddressAmount,

--- a/buyer-app/buyer-app/src/components/buyer/Buyer.js
+++ b/buyer-app/buyer-app/src/components/buyer/Buyer.js
@@ -134,7 +134,7 @@ class Buyer extends React.Component {
       R.values
     )(activeDataOrders);
 
-    const openOrders = dataOrdersAddressAmount.data? dataOrdersAddressAmount.data.openOrdersLength : 0;
+    const openOrders = dataOrdersAddressAmount.data? dataOrdersAddressAmount.data.totalOpenOrders : 0;
 
     const panels = [
       <BalancePanel

--- a/buyer-app/buyer-app/src/components/buyer/Buyer.js
+++ b/buyer-app/buyer-app/src/components/buyer/Buyer.js
@@ -37,11 +37,27 @@ import DataOrderCreate from "./DataOrderCreate";
 import { removeCookie } from "../../utils/cookies"
 
 import R from "ramda";
-import queryString from 'query-string';
+
+const limit = 1;
 
 class Buyer extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      currentOffset: 0,
+    };
+  }
+
+  componentDidMount() {
+    window.addEventListener('scroll', this.handleScroll, true);
+  }
+
   componentWillMount() {
     this.props.fetchDataOrders();
+  }
+
+  componentWillUnmount() {
+    window.removeEventListener('scroll', this.handleScroll);
   }
 
   handleSelectClick = value => {
@@ -54,6 +70,15 @@ class Buyer extends React.Component {
     removeCookie('token')
     this.props.logOutUser();
   };
+
+  handleScroll = () =>{
+    if(this.isLoading()) return;
+    console.log('[SCROLLLLLLL!!]');
+      this.setState((state, props) => ({
+        currentOffset: state.currentOffset + 1,
+      }));
+      this.props.fetchDataOrders(this.state);
+  }
 
   renderSelect() {
     return (
@@ -133,7 +158,7 @@ class Buyer extends React.Component {
             <div className={cx("action-buttons")}>
               <Button
                 onClick={() => {
-                  this.props.fetchDataOrders();
+                  this.props.fetchDataOrders(this.state);
                 }}
               >
                 Refresh
@@ -192,12 +217,16 @@ const mapDispatchToProps = (dispatch, props) => ({
   startPollingDataOrders: () => {
     dispatch(PollingActions.startPollingDataOrders());
   },
-  fetchDataOrders: () => {
-    const { limit, offset } = queryString.parse(props.location.search);
+  fetchDataOrders: (params) => {
+    const { currentOffset } = params || {};
+    console.log({
+      limit: Number(limit),
+      offset: Number(currentOffset || 0)
+    });
     dispatch(
       DataOrdersAddressesActions.fetchDataOrdersAddresses({
-        limit: Number(limit || 10),
-        offset: Number(offset || -10)
+        limit: Number(limit),
+        offset: Number(currentOffset || 0)
       })
     );
   },

--- a/buyer-app/buyer-app/src/components/buyer/Buyer.js
+++ b/buyer-app/buyer-app/src/components/buyer/Buyer.js
@@ -40,7 +40,7 @@ import { removeCookie } from "../../utils/cookies"
 
 import R from "ramda";
 
-const limit = 1;
+const limit = 12;
 
 class Buyer extends React.Component {
   constructor(props) {
@@ -82,12 +82,11 @@ class Buyer extends React.Component {
       dataOrdersAddressAmount,
       closedDataOrders,
     } = this.props;
-    console.log(activeDataOrders);
     const loadedOrders = Object.entries(activeDataOrders) + Object.entries(closedDataOrders);
     if (bottom && !this.isLoading() && loadedOrders < dataOrdersAddressAmount)
     {
       this.setState((state, props) => ({
-        currentOffset: state.currentOffset + 1,
+        currentOffset: state.currentOffset + limit,
       }));
       this.props.fetchDataOrders(this.state);
     }

--- a/buyer-app/buyer-app/src/lib/protocol-helpers/data-orders.js
+++ b/buyer-app/buyer-app/src/lib/protocol-helpers/data-orders.js
@@ -15,12 +15,28 @@ async function listBuyerDataOrders(limit, offset) {
     }
   });
   if (!res.ok) {
-    throw new Error('Could get data orders');
+    throw new Error('Could not get data orders');
   }
 
   const orders = await res.json();
 
   return orders;
+}
+
+async function getBuyerDataOrdersAmount() {
+  const res = await fetch(`${apiUrl}/orders/total`,
+  {
+    headers: {
+      Authorization: authorization()
+    }
+  });
+  if (!res.ok) {
+    throw new Error('Could not get data orders');
+  }
+
+  const ordersAmount = await res.json();
+
+  return ordersAmount;
 }
 
 async function createBuyerDataOrder(
@@ -93,6 +109,7 @@ const closeOrder = async orderAddress => {
 export {
   listBuyerDataOrders,
   createBuyerDataOrder,
+  getBuyerDataOrdersAmount,
   addNotariesToOrder,
   closeOrder,
 };

--- a/buyer-app/buyer-app/src/state/entities/dataOrdersAddressesAmount/actions.js
+++ b/buyer-app/buyer-app/src/state/entities/dataOrdersAddressesAmount/actions.js
@@ -1,0 +1,15 @@
+import { createAction } from "redux-act";
+
+const fetchDataOrdersAddressesAmount = createAction("DATA_ORDER_ADDRESSES_AMOUNT_FETCH");
+const fetchDataOrdersAddressesAmountSucceed = createAction(
+  "DATA_ORDER_ADDRESSES_AMOUNT_FETCH_SUCCEED"
+);
+const fetchDataOrdersAddressesAmountFailed = createAction(
+  "DATA_ORDER_ADDRESSES_AMOUNT_FETCH_FAILED"
+);
+
+export {
+  fetchDataOrdersAddressesAmount,
+  fetchDataOrdersAddressesAmountSucceed,
+  fetchDataOrdersAddressesAmountFailed
+};

--- a/buyer-app/buyer-app/src/state/entities/dataOrdersAddressesAmount/reducers.js
+++ b/buyer-app/buyer-app/src/state/entities/dataOrdersAddressesAmount/reducers.js
@@ -1,0 +1,33 @@
+import { createReducer } from "redux-act";
+
+import * as Actions from "./actions";
+
+const initialState = {
+  data: null,
+  fulfilled: false,
+  pending: false
+};
+
+export default createReducer(
+  {
+    [Actions.fetchDataOrdersAddressesAmount]: state => ({
+      ...state,
+      pending: true,
+      fulfilled: false,
+      error: false
+    }),
+    [Actions.fetchDataOrdersAddressesAmountFailed]: (state, { error }) => ({
+      ...state,
+      error,
+      pending: false,
+      fulfilled: false
+    }),
+    [Actions.fetchDataOrdersAddressesAmountSucceed]: (state, { data }) => ({
+      data,
+      error: false,
+      pending: false,
+      fulfilled: true
+    })
+  },
+  initialState
+);

--- a/buyer-app/buyer-app/src/state/entities/dataOrdersAddressesAmount/sagas.js
+++ b/buyer-app/buyer-app/src/state/entities/dataOrdersAddressesAmount/sagas.js
@@ -1,0 +1,31 @@
+import { throttle, put, all, call } from "redux-saga/effects";
+
+import * as DataOrdersHelpers from "lib/protocol-helpers/data-orders";
+import * as DataOrdersAddressesAmountActions from "state/entities/dataOrdersAddressesAmount/actions";
+
+export function* fetchDataOrdersAddressesAmount() {
+  try {
+    const dataOrdersAmount = yield call(DataOrdersHelpers.getBuyerDataOrdersAmount);
+    // console.log(dataOrdersAmount);
+
+    yield put(
+      DataOrdersAddressesAmountActions.fetchDataOrdersAddressesAmountSucceed({
+        data: dataOrdersAmount
+      })
+    );
+  } catch (error) {
+    yield put(DataOrdersAddressesAmountActions.fetchDataOrdersAddressesAmountFailed({ error }));
+  }
+}
+
+function* watchFetchDataOrdersAddressesAmount() {
+  yield throttle(
+    5000,
+    DataOrdersAddressesAmountActions.fetchDataOrdersAddressesAmount.getType(),
+    fetchDataOrdersAddressesAmount
+  );
+}
+
+export default function* rootSaga() {
+  yield all([watchFetchDataOrdersAddressesAmount()]);
+}

--- a/buyer-app/buyer-app/src/state/entities/dataOrdersAddressesAmount/selectors.js
+++ b/buyer-app/buyer-app/src/state/entities/dataOrdersAddressesAmount/selectors.js
@@ -1,0 +1,5 @@
+function getDataOrdersAddressesAmount(state) {
+  return state.dataOrdersAddressesAmount;
+}
+
+export { getDataOrdersAddressesAmount };

--- a/buyer-app/buyer-app/src/state/reducer/index.js
+++ b/buyer-app/buyer-app/src/state/reducer/index.js
@@ -4,6 +4,7 @@ import { routerReducer } from "react-router-redux";
 import createDataOrder from "state/entities/createDataOrder/reducers";
 import dataExchange from "state/entities/dataExchange/reducers";
 import dataOrdersAddresses from "state/entities/dataOrdersAddresses/reducers";
+import dataOrdersAddressesAmount from "state/entities/dataOrdersAddressesAmount/reducers";
 import dataOrdersByAddress from "state/entities/dataOrdersByAddress/reducers";
 import buyDataOrder from "state/entities/buyDataOrder/reducers";
 import notaries from "state/entities/notaries/reducers";
@@ -16,6 +17,7 @@ const reducers = {
   dataExchange,
   dataOrdersAddresses,
   dataOrdersByAddress,
+  dataOrdersAddressesAmount,
   buyDataOrder, // Should be called buyDataResponses
   notaries,
   account,

--- a/buyer-app/buyer-app/src/state/sagas/sagas.js
+++ b/buyer-app/buyer-app/src/state/sagas/sagas.js
@@ -4,6 +4,7 @@ import createDataOrderSagas from "state/entities/createDataOrder/sagas";
 import buyDataOrderSagas from "state/entities/buyDataOrder/sagas";
 import closeDataOrderSagas from "state/entities/closeDataOrder/sagas";
 import dataOrdersAddressesSagas from "state/entities/dataOrdersAddresses/sagas";
+import dataOrdersAddressesAmountSagas from "state/entities/dataOrdersAddressesAmount/sagas";
 import notariesSagas from "state/entities/notaries/sagas";
 import accountSagas from "state/entities/account/sagas";
 import notificationsSagas from "state/entities/notifications/sagas";
@@ -18,6 +19,7 @@ export default function* rootSaga() {
     pollingSagas(),
     createDataOrderSagas(),
     buyDataOrderSagas(),
+    dataOrdersAddressesAmountSagas(),
     closeDataOrderSagas(),
     notariesSagas(),
     accountSagas(),


### PR DESCRIPTION
Infinite scrolled implemented in `buyer app`. Now it's actually using the limit-offset approach of the API, and it's loading orders "on demand", when scrolling to the bottom of the page. The max amount of orders is set as _12_, maybe this could be configurable? 

## NOTES ## 
- _Open Data Orders_ is loaded just at the beginning (it's a count of all transactions of buyer), and it's **not** updated if the user creates a new order, maybe this could be updated as well?
- The GIF has a max amount of 2, just for showing how it works. The commited value is 12.

![infinite](https://user-images.githubusercontent.com/4080111/46414601-d5261800-c6f9-11e8-9679-a2365fbcdacf.gif)
