### PR TITLE
Close data response now calls on demand notarization

### DIFF
--- a/buyer-api/src/facades/dataResponseFacade/closeDataResponse.js
+++ b/buyer-api/src/facades/dataResponseFacade/closeDataResponse.js
@@ -10,12 +10,28 @@ import { getNotaryInfo } from '../notariesFacade';
 import { web3, DataOrderContract, logger } from '../../utils';
 import config from '../../../config';
 
-const auditResult = async (notaryUrl, order, seller, buyer) => {
-  const baseUri = notaryUrl.replace(/\/$/, '');
-  const auditUrl = `${baseUri}/buyers/audit/result/${buyer}/${order}`;
+const buildUri = (rootUrl, path) => {
+  const baseUri = rootUrl.replace(/\/$/, '');
+  const trimmedPath = path.replace(/^\//, '');
+  return `${baseUri}/${trimmedPath}`;
+};
+
+const postAudit = async (notaryUrl, order, seller, buyer, step) => {
+  const auditUrl = buildUri(notaryUrl, `buyers/audit/${step}/${buyer}/${order}`);
   const payload = { dataResponses: [{ seller }] };
   const response = await client.post(auditUrl, { json: payload, timeout: 1000 });
-  const { error, result, signature } = response.dataResponses[0];
+  return response.dataResponses[0];
+};
+
+const demandAudit = async (notaryUrl, order, seller, buyer) => {
+  const { error } = await postAudit(notaryUrl, order, seller, buyer, 'on-demand');
+  if (error) {
+    throw new Error(error);
+  }
+};
+
+const auditResult = async (notaryUrl, order, seller, buyer) => {
+  const { error, result, signature } = await postAudit(notaryUrl, order, seller, buyer, 'result');
 
   if (error) {
     throw new Error(error);
@@ -54,7 +70,9 @@ const closeDataResponse = async (order, seller, notariesCache, dataResponseQueue
   const notaryInfo = await getNotaryInfo(notaryAddress, notariesCache);
   const notaryApi = notaryInfo.publicUrls.api;
 
-  const params = await auditResult(notaryApi, order, seller, dataOrder.buyer());
+  const buyer = dataOrder.buyer();
+  await demandAudit(notaryApi, order, seller, buyer);
+  const params = await auditResult(notaryApi, order, seller, buyer);
 
   const { address } = await signingService.getAccount();
 


### PR DESCRIPTION
### What does this Pull Request do?
The buyer calls the notary to carry out a notarization for every single seller.

### Are there points in the code the reviewer needs to double check?
The notary doesn't bother if the on demand endpoint is called many times, but please check if this workflow as it is proposed has any unexpected impact.

### Why was this Pull Request needed?
The notary resolves to 'na' right now, unless the buyer demands an audit.
As there is no interest from the buyer right now to NOT buy unaudited data, the notarization process is always requested.

### Does this Pull Request meet the acceptance criteria?
- [x] I have read the [Contribution guidelines](https://github.com/wibsonorg/buyer-sdk/CONTRIBUTING.md).
- [x] I have read the [Code of Conduct](https://github.com/wibsonorg/buyer-sdk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
