### PR TITLE
Consolidating data responses and boughts on each bucket

### DIFF
--- a/buyer-api/src/facades/getBatchesFacade.js
+++ b/buyer-api/src/facades/getBatchesFacade.js
@@ -87,10 +87,15 @@ const getBatchInfo = async (batchId, orderAddresses, ordersCache, batchesCache) 
 const getBatches = async (
   ordersCache,
   batchesCache,
+  offset,
+  limit,
 ) => {
   const batchesRaw = await listBatchPairs();
 
-  const batches = await Promise.all(batchesRaw.map(batch =>
+  const upperBound = limit && offset >= 0 ? offset + limit : batchesRaw.length;
+  const batchesPage = batchesRaw.slice(offset, upperBound);
+
+  const batches = await Promise.all(batchesPage.map(batch =>
     getBatchInfo(batch.key, JSON.parse(batch.value), ordersCache, batchesCache)));
 
   return batches;

--- a/buyer-api/src/facades/getBatchesFacade.js
+++ b/buyer-api/src/facades/getBatchesFacade.js
@@ -16,6 +16,23 @@ const batchesTTL = Number(config.contracts.cache.ordersTTL);
 const addBatchToCache = (batch, batchesCache) =>
   batchesCache.set(batch.batchId, JSON.stringify(batch), 'EX', batchesTTL);
 
+const consolidateResponses = async (orderAddresses, ordersCache) => {
+  const dataOrders =
+    await Promise.all(orderAddresses.map(order => getDataOrder(order, ordersCache)));
+
+  const dataCount = dataOrders
+    .map(order => order.offChain.dataCount)
+    .reduce((accum, dataOrderCount) => accum + Number(dataOrderCount));
+  const dataResponsesCount = dataOrders
+    .map(order => order.offChain.dataResponsesCount)
+    .reduce((accum, dataOrderCount) => accum + Number(dataOrderCount));
+  const responsesBought = dataOrders
+    .map(order => order.responsesBought)
+    .reduce((accum, responses) => accum + Number(responses));
+
+  return { offChain: { dataCount, dataResponsesCount }, responsesBought };
+};
+
 /**
  * @async
  * @function fetchAndCacheBatch
@@ -28,9 +45,14 @@ const fetchAndCacheBatch = async (batchId, orderAddresses, ordersCache, batchesC
   const firstOrder = await getDataOrder(orderAddresses[0], ordersCache);
   // Removing orderAddress since they are grouped in orderAddresses
   const { orderAddress: deletedKey, ...orderProperties } = firstOrder;
+  const { offChain, responsesBought } = await consolidateResponses(orderAddresses, ordersCache);
 
-  await addBatchToCache({ batchId, ...orderProperties, orderAddresses }, batchesCache);
-  return { batchId, ...orderProperties, orderAddresses };
+  const newBatch = {
+    batchId, ...orderProperties, offChain, responsesBought, orderAddresses,
+  };
+
+  await addBatchToCache(newBatch, batchesCache);
+  return newBatch;
 };
 
 /**

--- a/buyer-api/src/routes/dataOrders/createDataOrder.js
+++ b/buyer-api/src/routes/dataOrders/createDataOrder.js
@@ -67,14 +67,18 @@ router.get(
   cache('10 minutes'),
   asyncError(async (req, res) => {
     req.apicacheGroup = '/orders/*';
-    const { address } = await signingService.getAccount();
 
-    const { stores: { ordersCache } } = req.app.locals;
+    const { stores: { ordersCache, batchesCache } } = req.app.locals;
 
-    const orders = await getOrdersAmountForBuyer(address, ordersCache);
+    // const { address } = await signingService.getAccount();
+    // FIXME: When implementing close of orders/batches
+    const batches = await getBatches(ordersCache, batchesCache);
 
-    const totalClosedOrders = orders.filter(order => order.isClosed).length;
-    const totalOpenOrders = orders.filter(order => !order.isClosed).length;
+    // const totalClosedOrders = batches.filter(order => order.isClosed).length;
+    // const totalOpenOrders = orders.filter(order => !order.isClosed).length;
+
+    const totalClosedOrders = 0;
+    const totalOpenOrders = batches.length;
 
     res.json({ totalClosedOrders, totalOpenOrders });
   }),

--- a/buyer-api/src/routes/dataOrders/createDataOrder.js
+++ b/buyer-api/src/routes/dataOrders/createDataOrder.js
@@ -1,5 +1,5 @@
 import express from 'express';
-import { getBatches, getOrdersAmountForBuyer } from '../../facades';
+import { getBatches } from '../../facades';
 import { asyncError, cache, dataExchange } from '../../utils';
 import signingService from '../../services/signingService';
 import { createBatch } from '../../services/batchInfo';

--- a/buyer-api/src/routes/dataOrders/createDataOrder.js
+++ b/buyer-api/src/routes/dataOrders/createDataOrder.js
@@ -24,25 +24,16 @@ router.get(
   cache('10 minutes'),
   asyncError(async (req, res) => {
     req.apicacheGroup = '/orders/*';
-    // const { offset, limit } = req.query;
-    // TODO: Improve DataOrder agregates
+    const { offset, limit } = req.query;
 
     const { stores: { ordersCache, batchesCache } } = req.app.locals;
 
-    const orders = await getBatches(ordersCache, batchesCache);
+    const orders = await getBatches(ordersCache, batchesCache, offset, limit);
 
     // HACK: This is just to fit what buyer-app is expecting
     orders.forEach((o) => { o.orderAddress = o.batchId; }); //eslint-disable-line
 
-    // const { children } = await signingService.getAccounts();
-    //
-    // const ordersResult = children
-    //   .map(({ address }) =>
-    // getOrdersForBuyer(address, ordersCache, Number(offset), Number(limit)));
-
     const minimumInitialBudgetForAudits = await dataExchange.minimumInitialBudgetForAudits();
-
-    // const orders = [].concat(...await Promise.all(ordersResult));
 
     res.json({ orders, minimumInitialBudgetForAudits });
   }),
@@ -70,12 +61,7 @@ router.get(
 
     const { stores: { ordersCache, batchesCache } } = req.app.locals;
 
-    // const { address } = await signingService.getAccount();
-    // FIXME: When implementing close of orders/batches
     const batches = await getBatches(ordersCache, batchesCache);
-
-    // const totalClosedOrders = batches.filter(order => order.isClosed).length;
-    // const totalOpenOrders = orders.filter(order => !order.isClosed).length;
 
     const totalClosedOrders = 0;
     const totalOpenOrders = batches.length;

--- a/buyer-api/src/services/batchInfo.js
+++ b/buyer-api/src/services/batchInfo.js
@@ -39,9 +39,11 @@ const createBatch = async (payload = []) => {
  */
 const associateOrderToBatch = async (batchId, orderAddress) => {
   try {
-    const raw = await ordersPerBatch.get(batchId);
-    const orderAddresses = JSON.parse(raw);
-    await ordersPerBatch.put(batchId, JSON.stringify(orderAddresses.concat(orderAddress)));
+    if (orderAddress) {
+      const raw = await ordersPerBatch.get(batchId);
+      const orderAddresses = JSON.parse(raw);
+      await ordersPerBatch.put(batchId, JSON.stringify(orderAddresses.concat(orderAddress)));
+    }
   } catch (err) {
     if (err.notFound) {
       await ordersPerBatch.put(batchId, [orderAddress]);


### PR DESCRIPTION
### What does this Pull Request do?
Adds logic for consolidating responses on `buyer-api` so it groups them on `buyer-app`

### Are there points in the code the reviewer needs to double check?
No

### Why was this Pull Request needed?
`buyer-app` was showing the responses of the first order of each wallet, now it's showing the `reduce` version of them

### Does this Pull Request meet the acceptance criteria?
- [X] I have read the [Contribution guidelines](https://github.com/wibsonorg/buyer-sdk/CONTRIBUTING.md).
- [X] I have read the [Code of Conduct](https://github.com/wibsonorg/buyer-sdk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
