### PR TITLE
Change DataOrders' filters structure and add ethAddress filter

### DIFF
--- a/buyer-api/src/facades/createDataOrderFacade.js
+++ b/buyer-api/src/facades/createDataOrderFacade.js
@@ -37,7 +37,8 @@ const buildDataOrderParameters = ({
   termsAndConditions,
   buyerURL,
 }) => ({
-  filters: JSON.stringify(filters),
+  filters: JSON.stringify(filters.reduce((accum, { filter, values }) =>
+    ({ ...accum, [filter]: values }), {})),
   dataRequest: JSON.stringify(dataRequest),
   price: fromWib(price),
   initialBudgetForAudits: fromWib(initialBudgetForAudits),
@@ -64,13 +65,27 @@ const buildDataOrderParameters = ({
  */
 const createDataOrderFacade = async (
   {
-    account, notaries, buyerInfoId, batchId, filters, ...parameters
+    account,
+    totalAccounts,
+    notaries,
+    buyerInfoId,
+    batchId,
+    filters,
+    ...parameters
   },
   addJob,
 ) => {
   const { termsHash } = await getBuyerInfo(buyerInfoId);
   const params = buildDataOrderParameters({
-    filters: [...filters, { filter: 'bucket', value: account.number }],
+    filters: [
+      ...filters, {
+        filter: 'ethAddress',
+        values: {
+          totalBuckets: totalAccounts,
+          bucketNumber: account.number,
+        }
+      }
+    ],
     ...parameters,
     termsAndConditions: termsHash,
   });

--- a/buyer-api/src/facades/createDataOrderFacade.js
+++ b/buyer-api/src/facades/createDataOrderFacade.js
@@ -49,6 +49,7 @@ const buildDataOrderParameters = ({
 /**
  * @async
  * @param {Object} parameters.account Account that sends the transaction.
+ * @param {Object} parameters.totalAccounts Number of children accounts.
  * @param {Object} parameters.filters Target audience.
  * @param {String} parameters.dataRequest Requested data type (Geolocation,
  *                 Facebook, etc).
@@ -83,8 +84,8 @@ const createDataOrderFacade = async (
         values: {
           totalBuckets: totalAccounts,
           bucketNumber: account.number,
-        }
-      }
+        },
+      },
     ],
     ...parameters,
     termsAndConditions: termsHash,

--- a/buyer-api/src/routes/dataOrders/createDataOrder.js
+++ b/buyer-api/src/routes/dataOrders/createDataOrder.js
@@ -200,6 +200,7 @@ router.post(
 
       children.forEach(account => queue.add('createDataOrder', {
         account,
+        totalAccounts: children.length,
         batchId,
         ...dataOrder,
       }, {


### PR DESCRIPTION
### What does this Pull Request do?
Changes the structure of the filters field that is sent to the blockchain to a more usable one. It is now an object instead of an array, so asking for a particular filters does not require a loop.
Also, the `ethAddress` filter is added containing `bucketNumber` and `totalBuckets` values so that Wibson API can show the DataOrder to the correct Seller.

### Why was this Pull Request needed?
So that Wibson API can show adequate information.

### Does this Pull Request meet the acceptance criteria?
- [x] I have read the [Contribution guidelines](https://github.com/wibsonorg/buyer-sdk/CONTRIBUTING.md).
- [x] I have read the [Code of Conduct](https://github.com/wibsonorg/buyer-sdk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
