### PR TITLE
Revert requestedData field structure

### DIFF
--- a/buyer-app/buyer-app/src/components/buyer/DataOrderCreate/DataOrderCreate.js
+++ b/buyer-app/buyer-app/src/components/buyer/DataOrderCreate/DataOrderCreate.js
@@ -113,7 +113,7 @@ class DataOrderCreate extends Component {
       };
     });
 
-    const data = requestedData ? [requestedData] : undefined;
+    const data = requestedData ? [requestedData.value] : undefined;
 
     const notaries = requestedNotaries.map((notaries)=> notaries.value);
 


### PR DESCRIPTION
### What does this Pull Request do?
Since the addition of the `ReactSelect`, the field value sent to create a DataOrder changed to `[{ value: 'geolocation' ... }]` from `['geolocation']`.

### Why was this Pull Request needed?
This PR reverts this change.

### Does this Pull Request meet the acceptance criteria?
- [x] I have read the [Contribution guidelines](https://github.com/wibsonorg/buyer-sdk/CONTRIBUTING.md).
- [x] I have read the [Code of Conduct](https://github.com/wibsonorg/buyer-sdk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
