### PR TITLE
Fix addNotaryToOrder param

### DIFF
--- a/buyer-api/src/facades/addNotariesToOrderFacade.js
+++ b/buyer-api/src/facades/addNotariesToOrderFacade.js
@@ -39,7 +39,11 @@ const takeOnlyNotariesToAdd = (orderAddress, addresses) => {
 
 /**
  * @async
- * @param {Object} params Transaction parameters
+ * @param {String} params.orderAddr DataOrder's ethereum address
+ * @param {String} params.responsesPercentage Percentage of response to notarize
+ * @param {String} params.notarizationFee Notary's fee
+ * @param {String} params.notarizationTermsOfService Notary's ToS
+ * @param {String} params.notarySignature Notary's consent signature
  * @param {String} buyerAddress Buyer's ethereum address
  * @param {Function} addNotaryToOrderSent Callback to notify that tx's been sent
  * @throws {Error} when AddNotaryToOrder transaction can't be sent
@@ -47,7 +51,7 @@ const takeOnlyNotariesToAdd = (orderAddress, addresses) => {
  */
 const addNotaryToOrder = async (params, buyerAddress, addNotaryToOrderSent) => {
   try {
-    const dataOrder = DataOrderContract.at(params.orderAddress);
+    const dataOrder = DataOrderContract.at(params.orderAddr);
     if (dataOrder.hasNotaryBeenAdded(params.notary)) {
       return;
     }
@@ -63,7 +67,7 @@ const addNotaryToOrder = async (params, buyerAddress, addNotaryToOrderSent) => {
     addNotaryToOrderSent({
       receipt,
       buyerAddress,
-      orderAddress: params.orderAddress,
+      orderAddress: params.orderAddr,
       notaryAddress: params.notary,
     });
   } catch (error) {


### PR DESCRIPTION
### What does this Pull Request do?
Fixes a bug regarding the `addNotaryToOrder` operation. The field `orderAddress` does not exist in the `params` object, and it is replaced with `orderAddr`.

### Does this Pull Request meet the acceptance criteria?
- [x] I have read the [Contribution guidelines](https://github.com/wibsonorg/buyer-sdk/CONTRIBUTING.md).
- [x] I have read the [Code of Conduct](https://github.com/wibsonorg/buyer-sdk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
