### PR TITLE
Use transaction names to enqueue transactions

### DIFF
--- a/buyer-api/src/facades/addNotariesToOrderFacade.js
+++ b/buyer-api/src/facades/addNotariesToOrderFacade.js
@@ -56,7 +56,7 @@ const addNotaryToOrder = async (account, params, enqueueTransaction) => {
 
   enqueueTransaction(
     account,
-    'signAddNotaryToOrder',
+    'AddNotaryToOrder',
     params,
     config.contracts.gasPrice.fast,
     { priority: priority.MEDIUM },

--- a/buyer-api/src/facades/closeDataOrderFacade.js
+++ b/buyer-api/src/facades/closeDataOrderFacade.js
@@ -38,7 +38,7 @@ const closeDataOrderFacade = async (orderAddr) => {
 
   enqueueTransaction(
     account,
-    'signCloseOrder',
+    'CloseOrder',
     { orderAddr },
     config.contracts.gasPrice.fast,
     { priority: priority.MEDIUM },

--- a/buyer-api/src/facades/createDataOrderFacade.js
+++ b/buyer-api/src/facades/createDataOrderFacade.js
@@ -118,7 +118,7 @@ const createDataOrderFacade = async (
 
   const job = await enqueueTransaction(
     account,
-    'signNewOrder',
+    'NewOrder',
     params,
     config.contracts.gasPrice.fast,
     {

--- a/buyer-api/src/facades/dataResponseFacade/addDataResponse.js
+++ b/buyer-api/src/facades/dataResponseFacade/addDataResponse.js
@@ -72,7 +72,7 @@ const addDataResponse = async (order, seller, enqueueTransaction) => {
 
   enqueueTransaction(
     account,
-    'signAddDataResponse',
+    'AddDataResponse',
     {
       orderAddr: order,
       seller,

--- a/buyer-api/src/facades/dataResponseFacade/closeDataResponse.js
+++ b/buyer-api/src/facades/dataResponseFacade/closeDataResponse.js
@@ -91,7 +91,7 @@ const closeDataResponse = async (
 
   enqueueTransaction(
     account,
-    'signCloseDataResponse',
+    'CloseDataResponse',
     params,
     config.contracts.gasPrice.fast,
     { priority: priority.LOW },

--- a/buyer-api/src/facades/dataResponseFacade/increaseApproval.js
+++ b/buyer-api/src/facades/dataResponseFacade/increaseApproval.js
@@ -20,7 +20,7 @@ const checkAllowance = async () => {
   if (minimumAllowance.isGreaterThan(allowance)) {
     enqueueTransaction(
       account,
-      'signIncreaseApproval',
+      'IncreaseApproval',
       {
         spender: dataExchange.options.address,
         addedValue: minimumAllowance.multipliedBy(multiplier),

--- a/buyer-api/src/queues/transactionQueue.js
+++ b/buyer-api/src/queues/transactionQueue.js
@@ -58,15 +58,15 @@ const createTransactionQueue = () => {
 };
 
 const transactionQueue = createTransactionQueue();
-const enqueueTransaction = (account, signWith, params, gasPrice, options = {}) => {
+const enqueueTransaction = (account, name, params, gasPrice, options = {}) => {
   const {
-    name, priority: p, attempts = 20, backoffType = 'linear',
+    priority: p, attempts = 20, backoffType = 'linear',
   } = options;
 
   return transactionQueue.add('perform', {
-    name: name || signWith.replace('sign', ''),
+    name,
     account,
-    signWith,
+    signWith: `sign${name}`,
     params,
     gasPrice,
   }, {


### PR DESCRIPTION
### What does this Pull Request do?
Changes the firm of the enqueueTransaction so that it uses tx names instead of signing method name.
