### PR TITLE
Fix utils imports

### DIFF
--- a/buyer-api/src/contractEventSubscribers/attachContractEventSubscribers.js
+++ b/buyer-api/src/contractEventSubscribers/attachContractEventSubscribers.js
@@ -1,5 +1,5 @@
-import { logger, dataExchange } from '.';
-import { eventBlocks } from './stores';
+import { logger, dataExchange } from '../utils';
+import { eventBlocks } from '../utils/stores';
 
 const invokeSubscribers = async (subscribers, result, stores) => {
   const invocableSubscribers = subscribers.filter(subscriber =>

--- a/buyer-api/src/contractEventSubscribers/index.js
+++ b/buyer-api/src/contractEventSubscribers/index.js
@@ -1,3 +1,4 @@
+import attachContractEventSubscribers from './attachContractEventSubscribers';
 import cacheUpdaterSubscriber from './cacheUpdaterSubscriber';
 import buyDataSubscriber from './buyDataSubscriber';
 
@@ -6,4 +7,6 @@ const subscribers = [
   buyDataSubscriber,
 ];
 
-export default subscribers;
+export default (stores, lastProcessedBlock) => {
+  attachContractEventSubscribers(subscribers, stores, lastProcessedBlock);
+};

--- a/buyer-api/src/routes/account.js
+++ b/buyer-api/src/routes/account.js
@@ -1,5 +1,6 @@
 import express from 'express';
-import { web3, cache, asyncError, wibcoin, coin } from '../utils';
+import { web3, cache, asyncError, wibcoin } from '../utils';
+import { coin } from '../utils/wibson-lib';
 import signingService from '../services/signingService';
 
 const router = express.Router();

--- a/buyer-api/src/server.js
+++ b/buyer-api/src/server.js
@@ -1,8 +1,8 @@
 import 'babel-polyfill';
 import app from './app';
 import config from '../config';
-import { logger, attachContractEventSubscribers } from './utils';
-import contractEventSubscribers from './contractEventSubscribers';
+import { logger } from './utils';
+import attach from './contractEventSubscribers';
 import { checkAllowance } from './facades';
 import { enqueueTransaction } from './queues';
 
@@ -11,15 +11,13 @@ const server = () => {
   app.listen({ port, host }, () =>
     logger.info(`Buyer API listening on port ${port} and host ${host} in ${env} mode`));
 
-  attachContractEventSubscribers(
-    contractEventSubscribers,
+  attach(
     app.locals.stores,
     config.eventSubscribers.lastProcessedBlock,
   );
 
   setInterval(
-    () => attachContractEventSubscribers(
-      contractEventSubscribers,
+    () => attach(
       app.locals.stores,
       config.eventSubscribers.lastProcessedBlock,
     ),

--- a/buyer-api/src/utils/delay.js
+++ b/buyer-api/src/utils/delay.js
@@ -1,3 +1,1 @@
-const delay = ms => new Promise((resolve) => { setTimeout(resolve, ms); });
-
-export { delay };
+export default ms => new Promise((resolve) => { setTimeout(resolve, ms); });

--- a/buyer-api/src/utils/index.js
+++ b/buyer-api/src/utils/index.js
@@ -2,10 +2,10 @@ import web3 from './web3';
 import cache from './cache';
 import logger from './logger';
 import fetchToken from './fetchToken';
-import attachContractEventSubscribers from './attachContractEventSubscribers';
 import checkAuthorization from './checkAuthorization';
+import delay from './delay';
 
-export { web3, cache, logger, attachContractEventSubscribers, fetchToken, checkAuthorization };
+export { web3, cache, logger, fetchToken, checkAuthorization, delay };
 export {
   createRedisStore,
   createLevelStore,
@@ -15,5 +15,3 @@ export {
 } from './storage';
 export { errorHandler, asyncError, validateAddress } from './routes';
 export { wibcoin, dataExchange, dataOrderAt } from './contracts';
-export { delay } from './delay';
-export { coin } from './wibson-lib';


### PR DESCRIPTION
### What does this Pull Request do?
* Moves `attachContractEventSubscribers` to `src/contractEventSubscribers`: this module imports `event_blocks` db which makes imports like `import { logger, wibcoin, ... } from 'utils';` unusable from another process because of the leveldb restriction. It also makes more sense to have the module there where it is used.
* Remove `wibson-lib/coin` import from `utils` and use it where it is needed.

### Does this Pull Request meet the acceptance criteria?
- [x] I have read the [Contribution guidelines](https://github.com/wibsonorg/buyer-sdk/CONTRIBUTING.md).
- [x] I have read the [Code of Conduct](https://github.com/wibsonorg/buyer-sdk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
