### PR TITLE
Store DataOrder DX ID as a number

### DIFF
--- a/buyer-api/src/blockchain/contractEventSubscribers.js
+++ b/buyer-api/src/blockchain/contractEventSubscribers.js
@@ -31,7 +31,8 @@ const getOrderId = async (dxId) => {
  * @function onDataOrderCreated Creates a dataOrderUpdater with the given status
  * @returns {dataOrderUpdater}
  */
-export const onDataOrderCreated = async ({ owner, orderId: dxId }, { transactionHash }) => {
+export const onDataOrderCreated = async ({ owner, orderId }, { transactionHash }) => {
+  const dxId = Number(orderId);
   const { address } = await getAccount();
   if (address.toLowerCase() === owner.toLowerCase()) {
     const { chainOrder, id } = await getOrderId(dxId);
@@ -56,7 +57,8 @@ export const onDataOrderCreated = async ({ owner, orderId: dxId }, { transaction
  * @function onDataOrderClosed Creates a closeDataOrder
  * @returns {closeDataOrder}
  */
-export const onDataOrderClosed = async ({ owner, orderId: dxId }) => {
+export const onDataOrderClosed = async ({ owner, orderId }) => {
+  const dxId = Number(orderId);
   const { address } = await getAccount();
   if (address.toLowerCase() === owner.toLowerCase()) {
     const { id } = await getOrderId(dxId);


### PR DESCRIPTION
### What does this Pull Request do?
This PR fixes DataOrder event handlers by casting the `orderId` parameter to a Number. The resulting value will be persisted as a Number.

### Are there points in the code the reviewer needs to double check?
No

### Why was this Pull Request needed?
Protocol v2 integration

### Does this Pull Request meet the acceptance criteria?
- [x] I have read the [Contribution guidelines](https://github.com/wibsonorg/buyer-sdk/CONTRIBUTING.md).
- [x] I have read the [Code of Conduct](https://github.com/wibsonorg/buyer-sdk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
